### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 static_assertions = { version = "1.1.0", default-features = false }
 unroll = { version = "0.1.5", default-features = false }
 
-p3-field = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-field", branch = "goldilocks_improvements"}
-p3-poseidon2 = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-poseidon2", branch = "goldilocks_improvements"}
-p3-goldilocks = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-goldilocks", branch = "goldilocks_improvements", features = ["nightly-features"]}
-p3-baby-bear = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-baby-bear", branch = "goldilocks_improvements", features = ["nightly-features"]}
-p3-symmetric = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-symmetric", branch = "goldilocks_improvements"}
-p3-monty-31 = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-monty-31", branch = "goldilocks_improvements", features = ["nightly-features"]}
-p3-field-testing = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-field-testing", branch = "goldilocks_improvements"}
-p3-dft = { git="https://github.com/telosnetwork/Plonky3.git", package = "p3-dft", branch = "goldilocks_improvements"}
+p3-field = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-field", branch = "goldilocks_improvements"}
+p3-poseidon2 = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-poseidon2", branch = "goldilocks_improvements"}
+p3-goldilocks = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-goldilocks", branch = "goldilocks_improvements", features = ["nightly-features"]}
+p3-baby-bear = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-baby-bear", branch = "goldilocks_improvements", features = ["nightly-features"]}
+p3-symmetric = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-symmetric", branch = "goldilocks_improvements"}
+p3-monty-31 = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-monty-31", branch = "goldilocks_improvements", features = ["nightly-features"]}
+p3-field-testing = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-field-testing", branch = "goldilocks_improvements"}
+p3-dft = { git="https://github.com/gigalabsofficial/Plonky3.git", package = "p3-dft", branch = "goldilocks_improvements"}
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ opt-level = 3
 opt-level = 3
 
 [workspace.package]
-version = "0.3.9"
+version = "0.4.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/0xPolygonZero/plonky2"


### PR DESCRIPTION
**Plonky3** dependencies have been switched to the `gigalabsofficial` organization repository.